### PR TITLE
feature/deploying-to-master

### DIFF
--- a/me/package.json
+++ b/me/package.json
@@ -19,7 +19,7 @@
     "test": "react-scripts test",
     "eject": "react-scripts eject",
     "predeploy": "yarn build",
-    "deploy": "gh-pages -d build"
+    "deploy": "gh-pages -b master -d build"
   },
   "eslintConfig": {
     "extends": "react-app"


### PR DESCRIPTION
Since I've decided to use `master` as the deployment branch I need to update my deploy script accordingly so that it doesn't deploy to the default `gh-pages` branch. This PR also corresponds to a switch to `dev` as the default branch for the repo.