### PR TITLE
Refactor gradient button to not use semanticUI

### DIFF
--- a/me/src/Helpers/sizes.ts
+++ b/me/src/Helpers/sizes.ts
@@ -1,3 +1,5 @@
 export enum sizes {
   borderSize = "0.175rem",
+  buttonVerticalPadding = "0.75rem",
+  buttonHorizontalPadding = "1.5rem",
 }

--- a/me/src/components/GradientButton/index.tsx
+++ b/me/src/components/GradientButton/index.tsx
@@ -1,47 +1,55 @@
-import { Button, ButtonProps } from "semantic-ui-react";
-import { GradientButtonProps } from "./props";
+// TODO: add a clicked state to button, hide border from screenreaders
+
+import {
+  GradientButtonBorderProps,
+  GradientButtonButtonProps,
+  GradientButtonProps,
+} from "./props";
 import React, { useState } from "react";
 import styled from "styled-components";
 import { linearGradientStyle } from "../../Helpers/paletteHelper";
+import { sizes } from "../../Helpers/sizes";
 
 const GradientButtonBorder = styled.div`
-  background: ${(props: GradientButtonProps) =>
+  background: ${(props: GradientButtonBorderProps) =>
     linearGradientStyle(45, props.gradientColorOne, props.gradientColorTwo)};
   display: inline-block;
-  padding: ${(props: GradientButtonProps) => props.gradientBorderSize};
+  padding: ${(props: GradientButtonBorderProps) => props.gradientBorderSize};
   border-radius: 100rem;
   cursor: pointer;
 `;
 
-const StyledSemanticButton = styled(Button)`
-  ${(props: GradientButtonProps) =>
+const StyledButton = styled.button`
+  border-radius: 100rem;
+  border: none;
+  padding: ${`${sizes.buttonVerticalPadding} ${sizes.buttonHorizontalPadding}`};
+  ${(props: GradientButtonButtonProps & { isHovered: boolean }) =>
     props.isHovered
-      ? `background: transparent none !important; color: ${props.unhoveredTextColor} !important;`
-      : `background: ${props.buttonColor} !important; color: ${props.hoveredTextColor} !important;`}
+      ? `background: transparent none; color: ${props.unhoveredTextColor};`
+      : `background: ${props.buttonColor}; color: ${props.hoveredTextColor};`}
 `;
 
-export const GradientButton = (props: GradientButtonProps) => {
+export const GradientButton: React.FC<GradientButtonProps> = (props) => {
   const [isHovered, setIsHovered] = useState(false);
+  const borderProps = props as GradientButtonBorderProps;
+  const buttonProps = props as GradientButtonButtonProps;
 
   return (
     <GradientButtonBorder
       onMouseEnter={() => setIsHovered(true)}
       onMouseLeave={() => setIsHovered(false)}
       onClick={props.onClick}
-      {...props}
+      {...borderProps}
     >
-      <StyledSemanticButton
-        {...{ ...props, isHovered }}
-        onClick={(
-          event: React.MouseEvent<HTMLButtonElement, MouseEvent>,
-          data: ButtonProps
-        ) => {
+      <StyledButton
+        {...{ ...buttonProps, isHovered }}
+        onClick={(event: React.MouseEvent<HTMLElement>) => {
           event.stopPropagation();
-          props.onClick && props.onClick(event, data);
+          props.onClick && props.onClick(event);
         }}
       >
         {props.children}
-      </StyledSemanticButton>
+      </StyledButton>
     </GradientButtonBorder>
   );
 };

--- a/me/src/components/GradientButton/props.ts
+++ b/me/src/components/GradientButton/props.ts
@@ -1,12 +1,21 @@
-import { ButtonProps } from "semantic-ui-react";
+import React from "react";
 import { colors } from "../../Helpers/palette";
 import { sizes } from "../../Helpers/sizes";
 
-export interface GradientButtonProps extends ButtonProps {
+export interface GradientButtonBorderProps {
   gradientBorderSize: `${sizes}`;
   gradientColorOne: `${colors}`;
   gradientColorTwo: `${colors}`;
+}
+
+export interface GradientButtonButtonProps {
   buttonColor: `${colors}`;
   unhoveredTextColor: `${colors}`;
   hoveredTextColor: `${colors}`;
+}
+
+export interface GradientButtonProps
+  extends GradientButtonBorderProps,
+    GradientButtonButtonProps {
+  onClick: (event: React.MouseEvent<HTMLElement>) => void;
 }


### PR DESCRIPTION
Since the GradientButton component is at this stage leveraging very little from the Semantic Button component, it is sensible to style is off of the intrinsic <button>, which gives the advantage of not needing to use the `!important` rule to get styles through the specificity of Semantic classes.